### PR TITLE
Additional type hints and other neatness changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.viewcode"
+    "sphinx.ext.viewcode",
 ]
 source_suffix = ".rst"
 master_doc = "index"

--- a/tests/test_yippiasync.py
+++ b/tests/test_yippiasync.py
@@ -194,7 +194,7 @@ async def test_pools(client):
     assert not pool.is_active
     assert pool.category == "series"
     assert not pool.is_deleted
-    assert set([653514, 653515, 653820]).issubset(pool.post_ids)
+    assert {653514, 653515, 653820}.issubset(pool.post_ids)
     assert pool.creator_name == "Emserdalf"
     assert pool.post_count == 48
 

--- a/tests/test_yippisync.py
+++ b/tests/test_yippisync.py
@@ -178,7 +178,7 @@ def test_pools(client):
     assert not pool.is_active
     assert pool.category == "series"
     assert not pool.is_deleted
-    assert set([653514, 653515, 653820]).issubset(pool.post_ids)
+    assert {653514, 653515, 653820}.issubset(pool.post_ids)
     assert pool.creator_name == "Emserdalf"
     assert pool.post_count == 48
 

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
-from typing import Awaitable
+from typing import Awaitable, Optional
 from typing import List
 from typing import Tuple
 from typing import TypeVar
@@ -57,7 +57,7 @@ class AbstractYippi(ABC):
     @abstractmethod
     def _call_api(
         self, method: str, url: str, data: dict = None, **kwargs
-    ) -> MaybeAwaitable[Union[List[dict], dict]]:
+    ) -> MaybeAwaitable[Optional[Union[List[dict], dict]]]:
         """Calls the API with specified method and url.
 
         Args:

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -47,7 +47,10 @@ class AbstractYippi(ABC):
     VALID_ORDER = ("name", "created_at", "updated_at", "post_count")
 
     def __init__(
-        self, project_name: str, version: str, creator: str,
+        self,
+        project_name: str,
+        version: str,
+        creator: str,
     ) -> None:
         self.headers = {
             "User-Agent": f"{project_name}/{version} (by {creator} on e621)"
@@ -73,7 +76,9 @@ class AbstractYippi(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _verify_response(self, r: Union[requests.Response, aiohttp.ClientResponse]) -> MaybeAwaitable[None]:
+    def _verify_response(
+        self, r: Union[requests.Response, aiohttp.ClientResponse]
+    ) -> MaybeAwaitable[None]:
         """Verifies response from server.
 
         Args:

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -48,7 +48,7 @@ class AbstractYippi(ABC):
 
     def __init__(
         self, project_name: str, version: str, creator: str,
-    ):
+    ) -> None:
         self.headers = {
             "User-Agent": f"{project_name}/{version} (by {creator} on e621)"
         }
@@ -73,7 +73,7 @@ class AbstractYippi(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _verify_response(self, r: Union[requests.Response, aiohttp.ClientResponse]):
+    def _verify_response(self, r: Union[requests.Response, aiohttp.ClientResponse]) -> None:
         """Verifies response from server.
 
         Args:
@@ -333,7 +333,7 @@ class AbstractYippi(ABC):
         url = POOL_URL + str(pool_id) + ".json"
         return self._call_api("GET", url)  # type: ignore
 
-    def login(self, username: str, api_key: str):
+    def login(self, username: str, api_key: str) -> None:
         """Supply login credentials to client.
 
         Args:

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -404,7 +404,7 @@ class AbstractYippi(ABC):
         post_id: int = None,
         post_tags_match: Union[List, str] = None,
         creator_name: str = None,
-        creator_id: str = None,
+        creator_id: int = None,
         is_active: bool = None,
         limit: int = None,
     ) -> MaybeAwaitable[List[Note]]:

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -377,7 +377,11 @@ class AbstractYippi(ABC):
 
     @abstractmethod
     def flags(
-        self, post_id: int = None, creator_id: int = None, creator_name: str = None
+        self,
+        post_id: int = None,
+        creator_id: int = None,
+        creator_name: str = None,
+        limit: int = None,
     ) -> MaybeAwaitable[List[Flag]]:
         """Search for flags
 

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -57,7 +57,7 @@ class AbstractYippi(ABC):
     @abstractmethod
     def _call_api(
         self, method: str, url: str, data: dict = None, **kwargs
-    ) -> Union[List[dict], dict]:
+    ) -> MaybeAwaitable[Union[List[dict], dict]]:
         """Calls the API with specified method and url.
 
         Args:
@@ -73,7 +73,7 @@ class AbstractYippi(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _verify_response(self, r: Union[requests.Response, aiohttp.ClientResponse]) -> None:
+    def _verify_response(self, r: Union[requests.Response, aiohttp.ClientResponse]) -> MaybeAwaitable[None]:
         """Verifies response from server.
 
         Args:

--- a/yippi/AbstractYippi.py
+++ b/yippi/AbstractYippi.py
@@ -197,7 +197,7 @@ class AbstractYippi(ABC):
         post_id: int = None,
         post_tags_match: Union[List, str] = None,
         creator_name: str = None,
-        creator_id: str = None,
+        creator_id: int = None,
         is_active: bool = None,
         limit: int = None,
     ) -> ArrayRequestResponse:

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -98,7 +98,7 @@ class AsyncYippiClient(AbstractYippi):
         post_id: int = None,
         post_tags_match: Union[List, str] = None,
         creator_name: str = None,
-        creator_id: str = None,
+        creator_id: int = None,
         is_active: bool = None,
         limit: int = None,
     ) -> List[Note]:

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from typing import Union
 
 import aiohttp
@@ -18,7 +18,7 @@ from .Exceptions import UserError
 class AsyncYippiClient(AbstractYippi):
     def __init__(
         self, *args, loop=None, session: aiohttp.ClientSession = None, **kwargs
-    ):
+    ) -> None:
         self._loop = loop
         self._session: aiohttp.ClientSession = session or aiohttp.ClientSession()
         super().__init__(*args, **kwargs)
@@ -34,7 +34,14 @@ class AsyncYippiClient(AbstractYippi):
 
     @sleep_and_retry
     @limits(calls=2, period=1)
-    async def _call_api(self, method: str, url: str, data: dict = None, file=None, **kwargs):
+    async def _call_api(
+        self,
+        method: str,
+        url: str,
+        data: dict = None,
+        file=None,
+        **kwargs
+    ) -> Optional[Union[List[dict], dict]]:
         auth = None
         if self._login != ("", ""):
             auth = BasicAuth(*self._login)

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -66,7 +66,13 @@ class AsyncYippiClient(AbstractYippi):
         elif r.status >= 500:
             raise APIError(r.reason)
 
-        if "application/json" not in r.headers.get("Content-Type") and r.status != 204:
+        if (
+            r.status != 204
+            and (
+                not r.headers.get("Content-Type")
+                or "application/json" not in r.headers.get("Content-Type")
+            )
+        ):
             res = await r.text()
             if "Not found." in res:
                 raise UserError("Not found.")

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -57,7 +57,7 @@ class AsyncYippiClient(AbstractYippi):
         if not r.status == 204:
             return await r.json()
 
-    async def _verify_response(self, r):
+    async def _verify_response(self, r) -> None:
         if r.status >= 300 and r.status < 500:
             res = await r.json()
             if r.status >= 400:
@@ -77,12 +77,12 @@ class AsyncYippiClient(AbstractYippi):
         tags: Union[List, str] = None,
         limit: int = None,
         page: Union[int, str] = None,
-    ):
+    ) -> List[Post]:
         response = await self._get_posts(tags, limit, page)  # type: ignore
         posts = [Post(p, client=self) for p in response["posts"]]
         return posts
 
-    async def post(self, post_id: int):
+    async def post(self, post_id: int) -> Post:
         api_res = await self._get_post(post_id)  # type: ignore
         return Post(api_res["post"], client=self)
 
@@ -95,7 +95,7 @@ class AsyncYippiClient(AbstractYippi):
         creator_id: str = None,
         is_active: bool = None,
         limit: int = None,
-    ):
+    ) -> List[Note]:
         response = await self._get_notes(
             body_matches,
             post_id,
@@ -114,7 +114,7 @@ class AsyncYippiClient(AbstractYippi):
         creator_id: int = None,
         creator_name: str = None,
         limit: int = None,
-    ):
+    ) -> List[Flag]:
         response = await self._get_flags(post_id, creator_id, creator_name)  # type: ignore
         result = [Flag(f, client=self) for f in response]
         return result
@@ -131,7 +131,7 @@ class AsyncYippiClient(AbstractYippi):
         category: str = None,
         order: str = None,
         limit: int = None,
-    ):
+    ) -> List[Pool]:
         response = await self._get_pools(
             name_matches,
             id_,
@@ -147,6 +147,6 @@ class AsyncYippiClient(AbstractYippi):
         result = [Pool(p, client=self) for p in response]
         return result
 
-    async def pool(self, pool_id: int):
+    async def pool(self, pool_id: int) -> Pool:
         response = await self._get_pool(pool_id)  # type: ignore
         return Pool(response, client=self)

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -58,7 +58,7 @@ class AsyncYippiClient(AbstractYippi):
             return await r.json()
 
     async def _verify_response(self, r) -> None:
-        if r.status >= 300 and r.status < 500:
+        if 300 <= r.status < 500:
             res = await r.json()
             if r.status >= 400:
                 raise UserError(res.get("message") or res.get("reason"), json=res)

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -35,12 +35,7 @@ class AsyncYippiClient(AbstractYippi):
     @sleep_and_retry
     @limits(calls=2, period=1)
     async def _call_api(
-        self,
-        method: str,
-        url: str,
-        data: dict = None,
-        file=None,
-        **kwargs
+        self, method: str, url: str, data: dict = None, file=None, **kwargs
     ) -> Optional[Union[List[dict], dict]]:
         auth = None
         if self._login != ("", ""):
@@ -73,12 +68,9 @@ class AsyncYippiClient(AbstractYippi):
         elif r.status >= 500:
             raise APIError(r.reason)
 
-        if (
-            r.status != 204
-            and (
-                not r.headers.get("Content-Type")
-                or "application/json" not in r.headers.get("Content-Type")
-            )
+        if r.status != 204 and (
+            not r.headers.get("Content-Type")
+            or "application/json" not in r.headers.get("Content-Type")
         ):
             res = await r.text()
             if "Not found." in res:

--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -34,7 +34,7 @@ class AsyncYippiClient(AbstractYippi):
 
     @sleep_and_retry
     @limits(calls=2, period=1)
-    async def _call_api(self, method, url, data=None, file=None, **kwargs):
+    async def _call_api(self, method: str, url: str, data: dict = None, file=None, **kwargs):
         auth = None
         if self._login != ("", ""):
             auth = BasicAuth(*self._login)

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -199,7 +199,7 @@ class Post(_BaseMixin):
         return api_response
 
     @classmethod
-    def from_file(cls, path) -> 'Post':
+    def from_file(cls, path) -> "Post":
         new_post = cls()
         new_post.file = open(path, "rb")
         new_post.file_path = path
@@ -207,7 +207,7 @@ class Post(_BaseMixin):
         return new_post
 
     @classmethod
-    def from_url(cls, url) -> 'Post':
+    def from_url(cls, url) -> "Post":
         if not regex.match(url):
             raise ValueError(f'URL "{url}" is invalid.')
         new_post = cls()
@@ -634,7 +634,7 @@ class Flag(_BaseMixin):
     def __repr__(self) -> str:
         return f"Flag(id={self.id})"
 
-    def get_post(self) -> 'Post':
+    def get_post(self) -> "Post":
         """Fetch the post linked with this flag.
 
         Returns:

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -318,11 +318,10 @@ class Post(_BaseMixin):
         post_data = {"post_id": str(self.id)}
         return self._client._call_api("POST", FAVORITES_URL + ".json", data=post_data)
 
-    def unfavorite(self) -> dict:
+    def unfavorite(self) -> None:
         if not self._original_data:
             raise UserError("Post object did not come from Post endpoint.")
-
-        return self._client._call_api("DELETE", f"{FAVORITES_URL}/{str(self.id)}.json")
+        self._client._call_api("DELETE", f"{FAVORITES_URL}/{str(self.id)}.json")
 
 
 class Note(_BaseMixin):
@@ -462,7 +461,7 @@ class Note(_BaseMixin):
 
     def delete(self) -> None:
         warnings.warn("This function has not been tested and should not be used.")
-        return self._client._call_api("DELETE", NOTE_URL + str(self.id))
+        self._client._call_api("DELETE", NOTE_URL + str(self.id))
 
 
 class Pool(_BaseMixin):

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -40,7 +40,7 @@ regex = re.compile(
 
 
 class _BaseMixin:
-    def __init__(self, json_data: dict, client: AbstractYippi = None):
+    def __init__(self, json_data: dict, client: AbstractYippi = None) -> None:
         if json_data:
             self._original_data: dict = deepcopy(json_data)
             self.id: Optional[int] = json_data.get("id")
@@ -63,7 +63,7 @@ class Post(_BaseMixin):
         https://e621.net/wiki_pages/2425
     """
 
-    def __init__(self, json_data=None, *args, **kwargs):
+    def __init__(self, json_data=None, *args, **kwargs) -> None:
         super().__init__(json_data, *args, **kwargs)
         self.file_path: Optional[str] = None
         self.file_url: Optional[str] = None
@@ -199,7 +199,7 @@ class Post(_BaseMixin):
         return api_response
 
     @classmethod
-    def from_file(cls, path):
+    def from_file(cls, path) -> 'Post':
         new_post = cls()
         new_post.file = open(path, "rb")
         new_post.file_path = path
@@ -207,14 +207,14 @@ class Post(_BaseMixin):
         return new_post
 
     @classmethod
-    def from_url(cls, url):
+    def from_url(cls, url) -> 'Post':
         if not regex.match(url):
             raise ValueError(f'URL "{url}" is invalid.')
         new_post = cls()
         new_post.file_url = url
         return new_post
 
-    def upload(self):
+    def upload(self) -> None:
         warnings.warn("This function has not been tested and should not be used.")
         if isinstance(self.tags, str):
             tags = self.tags
@@ -249,7 +249,7 @@ class Post(_BaseMixin):
 
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 
-    def update(self, has_notes: bool, reason: str = None):
+    def update(self, has_notes: bool, reason: str = None) -> Union[List[dict], dict]:
         """Updates the post. **This function has not been tested.**
 
         Args:
@@ -311,14 +311,14 @@ class Post(_BaseMixin):
 
         return self._client._call_api("PATCH", POST_URL + str(self.id), data=post_data)
 
-    def favorite(self):
+    def favorite(self) -> dict:
         if not self._original_data:
             raise UserError("Post object did not come from Post endpoint.")
 
         post_data = {"post_id": str(self.id)}
         return self._client._call_api("POST", FAVORITES_URL + ".json", data=post_data)
 
-    def unfavorite(self):
+    def unfavorite(self) -> dict:
         if not self._original_data:
             raise UserError("Post object did not come from Post endpoint.")
 
@@ -339,7 +339,7 @@ class Note(_BaseMixin):
         https://e621.net/wiki_pages/2425
     """
 
-    def __init__(self, json_data=None, *args, **kwargs):
+    def __init__(self, json_data=None, *args, **kwargs) -> None:
         super().__init__(json_data, *args, **kwargs)
         self.creator_id: int = json_data.get("creator_id")
         self.x: int = json_data.get("x")
@@ -352,7 +352,7 @@ class Note(_BaseMixin):
         self.body: str = json_data.get("body")
         self.creator_name: str = json_data.get("creator_name")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Note(id=%s)" % (self.id)
 
     def get_post(self) -> MaybeAwaitable["Post"]:
@@ -460,7 +460,7 @@ class Note(_BaseMixin):
         api_response = cast(dict, api_response)
         return api_response
 
-    def delete(self):
+    def delete(self) -> None:
         warnings.warn("This function has not been tested and should not be used.")
         return self._client._call_api("DELETE", NOTE_URL + str(self.id))
 
@@ -479,7 +479,7 @@ class Pool(_BaseMixin):
         https://e621.net/wiki_pages/2425
     """
 
-    def __init__(self, json_data=None, *args, **kwargs):
+    def __init__(self, json_data=None, *args, **kwargs) -> None:
         super().__init__(json_data, *args, **kwargs)
         if json_data:
             self.name: str = json_data.get("name")
@@ -492,7 +492,7 @@ class Pool(_BaseMixin):
             self.creator_name: str = json_data.get("creator_name")
             self.post_count: int = json_data.get("post_count")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Pool(id=%s, name=%s)" % (self.id, self.name)
 
     def _sort_posts(self, arr: List["Post"]) -> List["Post"]:
@@ -509,7 +509,7 @@ class Pool(_BaseMixin):
             sorted_array.append(next(p for p in arr if p.id == post_id))
         return sorted_array
 
-    def _register_linked(self, arr: List["Post"]):
+    def _register_linked(self, arr: List["Post"]) -> None:
         """Register a series of posts to have ``.continue`` and ``.previous`` attribute.
 
         Useful for those who are lazy to track down index number.
@@ -623,7 +623,7 @@ class Flag(_BaseMixin):
         https://e621.net/wiki_pages/2425
     """
 
-    def __init__(self, json_data=None, *args, **kwargs):
+    def __init__(self, json_data=None, *args, **kwargs) -> None:
         super().__init__(json_data, *args, **kwargs)
         if json_data:
             self.post_id: int = json_data.get("post_id")
@@ -632,10 +632,10 @@ class Flag(_BaseMixin):
             self.is_deletion: bool = json_data.get("is_deletion")
             self.category: str = json_data.get("category")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Flag(id=%s)" % (self.id)
 
-    def get_post(self):
+    def get_post(self) -> 'Post':
         """Fetch the post linked with this flag.
 
         Returns:
@@ -660,7 +660,7 @@ class TagCategory(IntEnum):
 
 
 class Tag(_BaseMixin):
-    def __init__(self, json_data=None, *args, **kwargs):
+    def __init__(self, json_data=None, *args, **kwargs) -> None:
         super().__init__(json_data, *args, **kwargs)
         if json_data:
             self.name: str = json_data.get("name")

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -89,11 +89,11 @@ class Post(_BaseMixin):
 
     def __repr__(self) -> str:
         if self.id:
-            name = "Post(id=%s)" % (self.id)
+            name = f"Post(id={self.id})"
         elif self.file_path:
-            name = "Post(file_path=%s)" % (self.file_path)
+            name = f"Post(file_path={self.file_path})"
         elif self.file_url:
-            name = "Post(file_url=%s)" % (self.file_url)
+            name = f"Post(file_url={self.file_url})"
         else:
             name = "Post()"
         return name
@@ -352,7 +352,7 @@ class Note(_BaseMixin):
         self.creator_name: str = json_data.get("creator_name")
 
     def __repr__(self) -> str:
-        return "Note(id=%s)" % (self.id)
+        return f"Note(id={self.id})"
 
     def get_post(self) -> MaybeAwaitable["Post"]:
         """Fetch the post linked with this note.
@@ -492,7 +492,7 @@ class Pool(_BaseMixin):
             self.post_count: int = json_data.get("post_count")
 
     def __repr__(self) -> str:
-        return "Pool(id=%s, name=%s)" % (self.id, self.name)
+        return f"Pool(id={self.id}, name={self.name})"
 
     def _sort_posts(self, arr: List["Post"]) -> List["Post"]:
         """Sort a list of post based on page numbering.
@@ -632,7 +632,7 @@ class Flag(_BaseMixin):
             self.category: str = json_data.get("category")
 
     def __repr__(self) -> str:
-        return "Flag(id=%s)" % (self.id)
+        return f"Flag(id={self.id})"
 
     def get_post(self) -> 'Post':
         """Fetch the post linked with this flag.

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -214,7 +214,7 @@ class Post(_BaseMixin):
         new_post.file_url = url
         return new_post
 
-    def upload(self) -> None:
+    def upload(self) -> dict:
         warnings.warn("This function has not been tested and should not be used.")
         if isinstance(self.tags, str):
             tags = self.tags

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -287,8 +287,8 @@ class Post(_BaseMixin):
             post_data["post[description]"] = self.description
             post_data["post[old_description]"] = original["description"]
 
-        if self.rating._value_ != original["rating"]:
-            post_data["post[rating]"] = self.rating._value_
+        if self.rating.value != original["rating"]:
+            post_data["post[rating]"] = self.rating.value
             post_data["post[old_rating]"] = original["rating"]
 
         if self.flags["rating_locked"] != original["flags"]["rating_locked"]:

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -244,8 +244,8 @@ class Post(_BaseMixin):
         if hasattr(self, "file_url"):
             post_data["upload[direct_url]"] = self.file_url
         else:
-            file_mime = mimetypes.guess_type(self.file_name)[0]
-            file = {"upload[file]": (self.file_name, self.file, file_mime, {})}
+            file_mime = mimetypes.guess_type(self.file_path)[0]
+            file = {"upload[file]": (self.file_path, self.file, file_mime, {})}
 
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 

--- a/yippi/Exceptions.py
+++ b/yippi/Exceptions.py
@@ -3,6 +3,6 @@ class APIError(Exception):
 
 
 class UserError(Exception):
-    def __init__(self, *args, json=None, **kwargs):
+    def __init__(self, *args, json=None, **kwargs) -> None:
         self.json = json
         super().__init__(*args, **kwargs)

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -22,12 +22,7 @@ class YippiClient(AbstractYippi):
     @sleep_and_retry
     @limits(calls=2, period=1)
     def _call_api(
-        self,
-        method: str,
-        url: str,
-        data: dict = None,
-        file=None,
-        **kwargs
+        self, method: str, url: str, data: dict = None, file=None, **kwargs
     ) -> Optional[Union[List[dict], dict]]:
         auth = None
         if self._login != ("", ""):
@@ -51,12 +46,9 @@ class YippiClient(AbstractYippi):
         elif r.status_code >= 500:
             raise APIError(r.reason)
 
-        if (
-            r.status_code != 204
-            and (
-                not r.headers.get("Content-Type")
-                or "application/json" not in r.headers.get("Content-Type")
-            )
+        if r.status_code != 204 and (
+            not r.headers.get("Content-Type")
+            or "application/json" not in r.headers.get("Content-Type")
         ):
             res = r.text
             if "Not found." in res:

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from typing import Union
 
 import requests
@@ -21,7 +21,14 @@ class YippiClient(AbstractYippi):
 
     @sleep_and_retry
     @limits(calls=2, period=1)
-    def _call_api(self, method: str, url: str, data: dict = None, file=None, **kwargs) -> dict:
+    def _call_api(
+        self,
+        method: str,
+        url: str,
+        data: dict = None,
+        file=None,
+        **kwargs
+    ) -> Optional[Union[List[dict], dict]]:
         auth = None
         if self._login != ("", ""):
             auth = HTTPBasicAuth(*self._login)

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -36,7 +36,7 @@ class YippiClient(AbstractYippi):
             return r.json()
 
     def _verify_response(self, r) -> None:
-        if r.status_code >= 300 and r.status_code < 500:
+        if 300 <= r.status_code < 500:
             res = r.json()
             if r.status_code >= 400:
                 raise UserError(res.get("message") or res.get("reason"), json=res)

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -76,7 +76,7 @@ class YippiClient(AbstractYippi):
         post_id: int = None,
         post_tags_match: Union[List, str] = None,
         creator_name: str = None,
-        creator_id: str = None,
+        creator_id: int = None,
         is_active: bool = None,
         limit: int = None,
     ) -> List[Note]:

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -45,8 +45,11 @@ class YippiClient(AbstractYippi):
             raise APIError(r.reason)
 
         if (
-            "application/json" not in r.headers.get("Content-Type")
-            and r.status_code != 204
+            r.status_code != 204
+            and (
+                not r.headers.get("Content-Type")
+                or "application/json" not in r.headers.get("Content-Type")
+            )
         ):
             res = r.text
             if "Not found." in res:

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -21,7 +21,7 @@ class YippiClient(AbstractYippi):
 
     @sleep_and_retry
     @limits(calls=2, period=1)
-    def _call_api(self, method, url, data=None, file=None, **kwargs) -> dict:
+    def _call_api(self, method: str, url: str, data: dict = None, file=None, **kwargs) -> dict:
         auth = None
         if self._login != ("", ""):
             auth = HTTPBasicAuth(*self._login)

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -15,13 +15,13 @@ from .Exceptions import UserError
 
 
 class YippiClient(AbstractYippi):
-    def __init__(self, *args, session: requests.Session = None, **kwargs):
+    def __init__(self, *args, session: requests.Session = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._session: requests.Session = session or requests.Session()
 
     @sleep_and_retry
     @limits(calls=2, period=1)
-    def _call_api(self, method, url, data=None, file=None, **kwargs):
+    def _call_api(self, method, url, data=None, file=None, **kwargs) -> dict:
         auth = None
         if self._login != ("", ""):
             auth = HTTPBasicAuth(*self._login)
@@ -35,7 +35,7 @@ class YippiClient(AbstractYippi):
         if not r.status_code == 204:
             return r.json()
 
-    def _verify_response(self, r):
+    def _verify_response(self, r) -> None:
         if r.status_code >= 300 and r.status_code < 500:
             res = r.json()
             if r.status_code >= 400:
@@ -58,12 +58,12 @@ class YippiClient(AbstractYippi):
         tags: Union[List, str] = None,
         limit: int = None,
         page: Union[int, str] = None,
-    ):
+    ) -> List[Post]:
         response = self._get_posts(tags, limit, page)
         result = [Post(p, client=self) for p in response["posts"]]  # type: ignore
         return result
 
-    def post(self, post_id: int):
+    def post(self, post_id: int) -> Post:
         response = self._get_post(post_id)
         return Post(response["post"], client=self)  # type: ignore
 
@@ -76,7 +76,7 @@ class YippiClient(AbstractYippi):
         creator_id: str = None,
         is_active: bool = None,
         limit: int = None,
-    ):
+    ) -> List[Note]:
         response = self._get_notes(
             body_matches,
             post_id,
@@ -95,7 +95,7 @@ class YippiClient(AbstractYippi):
         creator_id: int = None,
         creator_name: str = None,
         limit: int = None,
-    ):
+    ) -> List[Flag]:
         response = self._get_flags(post_id, creator_id, creator_name)
         result = [Flag(f, client=self) for f in response]  # type: ignore
         return result
@@ -112,7 +112,7 @@ class YippiClient(AbstractYippi):
         category: str = None,
         order: str = None,
         limit: int = None,
-    ):
+    ) -> List[Pool]:
         response = self._get_pools(
             name_matches,
             id_,
@@ -128,6 +128,6 @@ class YippiClient(AbstractYippi):
         result = [Pool(p, client=self) for p in response]  # type: ignore
         return result
 
-    def pool(self, pool_id: int):
+    def pool(self, pool_id: int) -> Pool:
         response = self._get_pool(pool_id)
         return Pool(response, client=self)  # type: ignore


### PR DESCRIPTION
Sorry, I started this branch with the intention to do more type hints but ended up also changing some other stuff, some bug fixes and some neatness changes

Bug fixes:
- Handling "Content-Type" headers being missing, for example with 204 responses.
- Swapping `file_name` to `file_path` in Post.upload(), as the former doesn't seem to exist

Neatness:
- Swapping remaining string formatting to f-strings
- Switching some stuff to set literals
- Adding `limit` arg to AbstractYippi.flags(), as it was in both implementations
- Chaining some response code checks
- Changing AbstractYippi.notes() `creator_id` argument to an int
- Using public `Enum.value` attribute rather than the `Enum._value_` attribute

If you would rather I broke this into separate pull requests, I can do that.

One question I have is that the aiohttp docs all have responses [handled in context managers](https://docs.aiohttp.org/en/stable/client_quickstart.html#json-response-content). Type hinting things there seemed to go oddly because it expected that, should this library be using responses in that context manager way?

Like, changing this:
```
r = await self._session.request(
    method, url, data=data, headers=self.headers, auth=auth
)
await self._verify_response(r)
if not r.status == 204:
    return await r.json()
```
to this:
```
async with self._session.request(
    method, url, data=data, headers=self.headers, auth=auth
) as r:
    await self._verify_response(r)
    if not r.status == 204:
        return await r.json()
```