### PR TITLE
Updating init arguments in Yippi clients

### DIFF
--- a/yippi/AsyncYippi.py
+++ b/yippi/AsyncYippi.py
@@ -18,11 +18,16 @@ from .Exceptions import UserError
 
 class AsyncYippiClient(AbstractYippi):
     def __init__(
-        self, *args, loop=None, session: aiohttp.ClientSession = None, **kwargs
+        self,
+        project_name: str,
+        version: str,
+        creator: str,
+        loop=None,
+        session: aiohttp.ClientSession = None,
     ) -> None:
         self._loop = loop
         self._session: aiohttp.ClientSession = session or aiohttp.ClientSession()
-        super().__init__(*args, **kwargs)
+        super().__init__(project_name, version, creator)
 
     async def close(self) -> None:
         await self._session.close()

--- a/yippi/YippiSync.py
+++ b/yippi/YippiSync.py
@@ -16,8 +16,14 @@ from .Exceptions import UserError
 
 
 class YippiClient(AbstractYippi):
-    def __init__(self, *args, session: requests.Session = None, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        project_name: str,
+        version: str,
+        creator: str,
+        session: requests.Session = None,
+    ) -> None:
+        super().__init__(project_name, version, creator)
         self._session: requests.Session = session or requests.Session()
 
     @limiter.ratelimit("call_api", delay=True)


### PR DESCRIPTION
This way, IDE's will know the arguments which are required for AbstractYippi. Catching *args, and **kwargs seems a little unnecessary