### PR TITLE
Post.update() shouldn't require has_notes argument

### DIFF
--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -95,6 +95,7 @@ class Post(_BaseMixin):
             self.description: str = json_data.get("description")
             self.comment_count: int = json_data.get("comment_count")
             self.is_favorited: bool = json_data.get("is_favorited")
+            self.has_notes: bool = json_data.get("has_notes")
 
     def __repr__(self) -> str:
         if self.id:
@@ -256,13 +257,12 @@ class Post(_BaseMixin):
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 
     def update(
-        self, reason: str = None, has_notes: bool = None
+        self, reason: str = None
     ) -> Union[List[dict], dict]:
         """Updates the post. **This function has not been tested.**
 
         Args:
             reason (optional): Reasoning behind the edit. Defaults to None.
-            has_notes (optional): Does the post have embedded notes or not.
 
         Raises:
             UserError: If the post did not come from any Post endpoint or if no changes has been made.
@@ -303,12 +303,12 @@ class Post(_BaseMixin):
 
         if self.flags["note_locked"] != original["flags"]["note_locked"]:
             post_data["post[is_note_locked]"] = str(self.flags["note_locked"]).lower()
+        
+        if self.has_notes != original["has_notes"]:
+            post_data["post[has_embedded_notes]"] = str(self.has_notes).lower()
 
         if not post_data:
             raise UserError("No changes has been made to the object.")
-
-        if has_notes is not None:
-            post_data["post[has_embedded_notes]"] = str(has_notes).lower()
 
         post_data["post[edit_reason]"] = reason or ""
 

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -255,7 +255,9 @@ class Post(_BaseMixin):
 
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 
-    def update(self, reason: str = None, has_notes: bool = None) -> Union[List[dict], dict]:
+    def update(
+        self, reason: str = None, has_notes: bool = None
+    ) -> Union[List[dict], dict]:
         """Updates the post. **This function has not been tested.**
 
         Args:

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -255,12 +255,12 @@ class Post(_BaseMixin):
 
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 
-    def update(self, has_notes: bool = None, reason: str = None) -> Union[List[dict], dict]:
+    def update(self, reason: str = None, has_notes: bool = None) -> Union[List[dict], dict]:
         """Updates the post. **This function has not been tested.**
 
         Args:
-            has_notes: Does the post have embedded notes or not.
             reason (optional): Reasoning behind the edit. Defaults to None.
+            has_notes (optional): Does the post have embedded notes or not.
 
         Raises:
             UserError: If the post did not come from any Post endpoint or if no changes has been made.

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -255,7 +255,7 @@ class Post(_BaseMixin):
 
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 
-    def update(self, has_notes: bool, reason: str = None) -> Union[List[dict], dict]:
+    def update(self, has_notes: bool = None, reason: str = None) -> Union[List[dict], dict]:
         """Updates the post. **This function has not been tested.**
 
         Args:
@@ -305,12 +305,10 @@ class Post(_BaseMixin):
         if not post_data:
             raise UserError("No changes has been made to the object.")
 
-        post_data.update(
-            {
-                "post[edit_reason]": reason or "",
-                "post[has_embedded_notes]": str(has_notes).lower(),
-            }
-        )
+        if has_notes is not None:
+            post_data["post[has_embedded_notes]"] = str(has_notes).lower()
+
+        post_data["post[edit_reason]"] = reason or ""
 
         return self._client._call_api(
             "PATCH", POST_URL + f"{self.id}.json", data=post_data

--- a/yippi/Classes.py
+++ b/yippi/Classes.py
@@ -256,9 +256,7 @@ class Post(_BaseMixin):
 
         return self._client._call_api("POST", UPLOAD_URL, files=file, data=post_data)
 
-    def update(
-        self, reason: str = None
-    ) -> Union[List[dict], dict]:
+    def update(self, reason: str = None) -> Union[List[dict], dict]:
         """Updates the post. **This function has not been tested.**
 
         Args:
@@ -303,7 +301,7 @@ class Post(_BaseMixin):
 
         if self.flags["note_locked"] != original["flags"]["note_locked"]:
             post_data["post[is_note_locked]"] = str(self.flags["note_locked"]).lower()
-        
+
         if self.has_notes != original["has_notes"]:
             post_data["post[has_embedded_notes]"] = str(self.has_notes).lower()
 


### PR DESCRIPTION
Making `has_notes` optional, and making reason the first argument. Hopefully this shouldn't break much, as it's still in the v0.* phase, so public API can change, and it's listed as untested.

I gave this a go manually, and it works fine for updating tags with reason. I'm not too sure how the has_notes setting even works here (surely one would just add notes?)

Questions:
1) Wasn't sure whether that `has_notes is not None` check on line 308 should go above the `if not post_data` check. I guess someone could update only that parameter?
2) After updating, it doesn't update the original data, so you have to create a new post object to do another update.. Does that seem okay, or should we automatically refresh it all?